### PR TITLE
Patch for electron 42

### DIFF
--- a/lib/debugger.cc
+++ b/lib/debugger.cc
@@ -4,6 +4,14 @@
  * https://github.com/ReClassNET/ReClass.NET
  */
 
+#ifdef _MSC_VER
+#ifndef __builtin_frame_address
+#include <intrin.h>
+#pragma intrinsic(_AddressOfReturnAddress)
+#define __builtin_frame_address(x) ((void*)_AddressOfReturnAddress())
+#endif
+#endif
+
 #include <node.h>
 #include <windows.h>
 #include <TlHelp32.h>

--- a/lib/dll.h
+++ b/lib/dll.h
@@ -2,7 +2,13 @@
 #ifndef DLL_H
 #define DLL_H
 #define WIN32_LEAN_AND_MEAN
-
+#ifdef _MSC_VER
+#ifndef __builtin_frame_address
+#include <intrin.h>
+#pragma intrinsic(_AddressOfReturnAddress)
+#define __builtin_frame_address(x) ((void*)_AddressOfReturnAddress())
+#endif
+#endif
 #include <napi.h>
 #include <windows.h>
 #include <TlHelp32.h>

--- a/lib/functions.cc
+++ b/lib/functions.cc
@@ -1,3 +1,11 @@
+#ifdef _MSC_VER
+#ifndef __builtin_frame_address
+#include <intrin.h>
+#pragma intrinsic(_AddressOfReturnAddress)
+#define __builtin_frame_address(x) ((void*)_AddressOfReturnAddress())
+#endif
+#endif
+
 #include <node.h>
 #include <windows.h>
 #include <TlHelp32.h>

--- a/lib/memory.cc
+++ b/lib/memory.cc
@@ -1,3 +1,11 @@
+#ifdef _MSC_VER
+#ifndef __builtin_frame_address
+#include <intrin.h>
+#pragma intrinsic(_AddressOfReturnAddress)
+#define __builtin_frame_address(x) ((void*)_AddressOfReturnAddress())
+#endif
+#endif
+
 #include <node.h>
 #include <windows.h>
 #include <TlHelp32.h>

--- a/lib/memoryjs.cc
+++ b/lib/memoryjs.cc
@@ -1,5 +1,12 @@
 #include <windows.h>
 #include <psapi.h>
+#ifdef _MSC_VER
+#ifndef __builtin_frame_address
+#include <intrin.h>
+#pragma intrinsic(_AddressOfReturnAddress)
+#define __builtin_frame_address(x) ((void*)_AddressOfReturnAddress())
+#endif
+#endif
 #include <napi.h>
 #include <string>
 #include "module.h"

--- a/lib/module.cc
+++ b/lib/module.cc
@@ -1,3 +1,11 @@
+#ifdef _MSC_VER
+#ifndef __builtin_frame_address
+#include <intrin.h>
+#pragma intrinsic(_AddressOfReturnAddress)
+#define __builtin_frame_address(x) ((void*)_AddressOfReturnAddress())
+#endif
+#endif
+
 #include <node.h>
 #include <windows.h>
 #include <TlHelp32.h>

--- a/lib/pattern.cc
+++ b/lib/pattern.cc
@@ -1,3 +1,11 @@
+#ifdef _MSC_VER
+#ifndef __builtin_frame_address
+#include <intrin.h>
+#pragma intrinsic(_AddressOfReturnAddress)
+#define __builtin_frame_address(x) ((void*)_AddressOfReturnAddress())
+#endif
+#endif
+
 #include <node.h>
 #include <windows.h>
 #include <TlHelp32.h>


### PR DESCRIPTION
feat: Add __builtin_frame_address definition for MSVC compatibility (to enable building under Electron 42)

See also https://github.com/agracio/electron-edge-js/issues/202 and https://github.com/agracio/electron-edge-js/pull/201 for more information